### PR TITLE
Add shadcn button to debug page

### DIFF
--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -1,0 +1,20 @@
+import { Button } from "@/components/ui/button"
+
+export default function DebugPage() {
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-2xl font-semibold">Debug Tools</h1>
+      <div className="flex flex-wrap gap-2">
+        <Button id="button-one">Button One</Button>
+        <Button id="button-two">Button Two</Button>
+        <Button id="button-three">Button Three</Button>
+      </div>
+      <section
+        id="debug-output"
+        className="mt-4 p-4 border rounded min-h-[100px]"
+      >
+        Debug output will appear here.
+      </section>
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }


### PR DESCRIPTION
## Summary
- implement Shadcn-style Button component under `src/components/ui`
- use the new Button on the `/debug` page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68568bcdd8a8832fbed1ccfd06edddec