### PR TITLE
Add emergency call page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Emergency Call Page
+
+Visit `/emergency-call` to view a mock emergency dialing interface. The page is optimized for mobile with a large call button and uses a simple animation while connecting.

--- a/src/app/emergency-call/page.tsx
+++ b/src/app/emergency-call/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Phone } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export default function EmergencyCallPage() {
+  const [status, setStatus] = useState<'idle' | 'dialing' | 'connected'>('idle')
+
+  useEffect(() => {
+    let timeout: NodeJS.Timeout
+    if (status === 'dialing') {
+      timeout = setTimeout(() => setStatus('connected'), 3000)
+    }
+    return () => clearTimeout(timeout)
+  }, [status])
+
+  const handleCall = () => {
+    if (status === 'idle') setStatus('dialing')
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-4 space-y-6">
+      <h1 className="text-2xl font-semibold">Emergency Call</h1>
+      <Button
+        aria-label="Call emergency services"
+        onClick={handleCall}
+        className={cn(
+          'rounded-full w-24 h-24 sm:w-32 sm:h-32 text-white bg-red-600 text-3xl sm:text-4xl shadow-lg active:scale-95',
+          status === 'idle' && 'animate-pulse'
+        )}
+      >
+        <Phone className="w-8 h-8 sm:w-10 sm:h-10" />
+      </Button>
+      <p className="text-lg h-6">
+        {status === 'idle' && 'Tap to call for help'}
+        {status === 'dialing' && 'Dialing…'}
+        {status === 'connected' && 'Connected'}
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add emergency call page with mock calling animation
- document `/emergency-call` page in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856995b11dc832f9a68c9e8109523c5