### PR TITLE
Add wallet page with QR code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.522.0",
         "next": "15.3.4",
+        "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.3.1"
@@ -5103,6 +5104,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.522.0",
     "next": "15.3.4",
+    "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.3.1"

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -1,0 +1,24 @@
+import { QRCodeSVG } from 'qrcode.react'
+
+export default function WalletPage() {
+  const name = "John Doe"; // placeholder name
+  const qrValue = `passport-${Math.random().toString(36).slice(2)}`;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-background text-foreground">
+      <div className="bg-card text-card-foreground rounded-xl shadow-md p-6 w-full max-w-sm space-y-4">
+        <h1 className="text-center text-xl font-semibold">Digital Wallet</h1>
+        <div className="text-center">
+          <p className="text-sm">Name</p>
+          <p className="font-medium text-lg">{name}</p>
+        </div>
+        <div className="flex justify-center">
+          <QRCodeSVG value={qrValue} size={180} level="Q" />
+        </div>
+        <p className="text-xs text-center text-muted-foreground">
+          Present this QR code as a one-time passport
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `qrcode.react` dependency
- implement digital wallet page with user name and one-time QR code

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685699c5101c832fb6a7207c310fd630