### PR TITLE
Add popover debug menu

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import DebugMenu from "@/components/DebugMenu";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,6 +29,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <DebugMenu />
       </body>
     </html>
   );

--- a/src/components/DebugMenu.tsx
+++ b/src/components/DebugMenu.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { useEffect, useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface DebugAction {
+  key: string;
+  label: string;
+  handler: () => void;
+}
+
+const actions: DebugAction[] = [
+  {
+    key: "1",
+    label: "Action One",
+    handler: () => console.log("Action one executed"),
+  },
+  {
+    key: "2",
+    label: "Action Two",
+    handler: () => console.log("Action two executed"),
+  },
+  {
+    key: "3",
+    label: "Action Three",
+    handler: () => console.log("Action three executed"),
+  },
+];
+
+export default function DebugMenu() {
+  const [open, setOpen] = useState(false);
+
+  const toggle = useCallback(() => setOpen((o) => !o), []);
+
+  const handleKey = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === "d" && e.shiftKey) {
+        e.preventDefault();
+        toggle();
+        return;
+      }
+      actions.forEach((action) => {
+        if (e.key === action.key) {
+          e.preventDefault();
+          action.handler();
+        }
+      });
+    },
+    [toggle]
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [handleKey]);
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      {open ? (
+        <div className="bg-popover text-popover-foreground border rounded shadow-lg p-4 space-y-2">
+          {actions.map((action) => (
+            <Button key={action.key} onClick={action.handler} className="w-full">
+              {action.label} ({action.key})
+            </Button>
+          ))}
+          <Button variant="secondary" onClick={toggle} className="w-full">
+            Close (Shift+D)
+          </Button>
+        </div>
+      ) : (
+        <Button size="icon" onClick={toggle} aria-label="Open debug menu">
+          D
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a small debug popover with keybinds
- include debug menu in the root layout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68569a55d5bc832fa99e233127f76159