### PR TITLE
Add mobile layout and new pages

### DIFF
--- a/src/app/chatbot/page.tsx
+++ b/src/app/chatbot/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+import MobileLayout from '../../components/MobileLayout'
+import { ChatInterface } from '@/components/chat/chat-interface'
+
+export default function ChatbotPage() {
+  return (
+    <MobileLayout>
+      <div className="flex min-h-screen items-center justify-center p-4 bg-zinc-900">
+        <ChatInterface />
+      </div>
+    </MobileLayout>
+  );
+}

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -1,20 +1,23 @@
 import { Button } from "@/components/ui/button"
+import MobileLayout from '../../components/MobileLayout'
 
 export default function DebugPage() {
   return (
-    <div className="p-8 space-y-4">
-      <h1 className="text-2xl font-semibold">Debug Tools</h1>
-      <div className="flex flex-wrap gap-2">
-        <Button id="button-one">Button One</Button>
-        <Button id="button-two">Button Two</Button>
-        <Button id="button-three">Button Three</Button>
+    <MobileLayout>
+      <div className="p-8 space-y-4">
+        <h1 className="text-2xl font-semibold">Debug Tools</h1>
+        <div className="flex flex-wrap gap-2">
+          <Button id="button-one">Button One</Button>
+          <Button id="button-two">Button Two</Button>
+          <Button id="button-three">Button Three</Button>
+        </div>
+        <section
+          id="debug-output"
+          className="mt-4 p-4 border rounded min-h-[100px]"
+        >
+          Debug output will appear here.
+        </section>
       </div>
-      <section
-        id="debug-output"
-        className="mt-4 p-4 border rounded min-h-[100px]"
-      >
-        Debug output will appear here.
-      </section>
-    </div>
+    </MobileLayout>
   );
 }

--- a/src/app/emergency-call/page.tsx
+++ b/src/app/emergency-call/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { Phone } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import MobileLayout from '../../components/MobileLayout'
 
 export default function EmergencyCallPage() {
   const [status, setStatus] = useState<'idle' | 'dialing' | 'connected'>('idle')
@@ -21,23 +22,25 @@ export default function EmergencyCallPage() {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen p-4 space-y-6">
-      <h1 className="text-2xl font-semibold">Emergency Call</h1>
-      <Button
-        aria-label="Call emergency services"
-        onClick={handleCall}
-        className={cn(
-          'rounded-full w-24 h-24 sm:w-32 sm:h-32 text-white bg-red-600 text-3xl sm:text-4xl shadow-lg active:scale-95',
-          status === 'idle' && 'animate-pulse'
-        )}
-      >
-        <Phone className="w-8 h-8 sm:w-10 sm:h-10" />
-      </Button>
-      <p className="text-lg h-6">
-        {status === 'idle' && 'Tap to call for help'}
-        {status === 'dialing' && 'Dialing…'}
-        {status === 'connected' && 'Connected'}
-      </p>
-    </div>
+    <MobileLayout>
+      <div className="flex flex-col items-center justify-center min-h-screen p-4 space-y-6">
+        <h1 className="text-2xl font-semibold">Emergency Call</h1>
+        <Button
+          aria-label="Call emergency services"
+          onClick={handleCall}
+          className={cn(
+            'rounded-full w-24 h-24 sm:w-32 sm:h-32 text-white bg-red-600 text-3xl sm:text-4xl shadow-lg active:scale-95',
+            status === 'idle' && 'animate-pulse'
+          )}
+        >
+          <Phone className="w-8 h-8 sm:w-10 sm:h-10" />
+        </Button>
+        <p className="text-lg h-6">
+          {status === 'idle' && 'Tap to call for help'}
+          {status === 'dialing' && 'Dialing…'}
+          {status === 'connected' && 'Connected'}
+        </p>
+      </div>
+    </MobileLayout>
   )
 }

--- a/src/app/liveticker/page.tsx
+++ b/src/app/liveticker/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+import MobileLayout from '../../components/MobileLayout'
+
+export default function LiveTickerPage() {
+  return (
+    <MobileLayout>
+      <main className="p-4 space-y-4 max-w-lg mx-auto">
+        <h1 className="text-xl font-semibold text-center">Live Ticker</h1>
+        <p className="text-muted-foreground text-center">No live updates available yet.</p>
+      </main>
+    </MobileLayout>
+  );
+}

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState } from "react";
+import MobileLayout from '../../components/MobileLayout'
 
 interface NewsItem {
   id: number;
@@ -68,10 +69,12 @@ export default function NewsPage() {
   );
 
   return (
-    <main className="p-4 max-w-xl mx-auto space-y-4 sm:p-6">
-      {sorted.map((item) => (
-        <NewsCard key={item.id} item={item} />
-      ))}
-    </main>
+    <MobileLayout>
+      <main className="p-4 max-w-xl mx-auto space-y-4 sm:p-6">
+        {sorted.map((item) => (
+          <NewsCard key={item.id} item={item} />
+        ))}
+      </main>
+    </MobileLayout>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+import MobileLayout from '../../components/MobileLayout'
+
+export default function SettingsPage() {
+  return (
+    <MobileLayout>
+      <main className="p-4 space-y-4 max-w-lg mx-auto">
+        <h1 className="text-xl font-semibold text-center">Settings</h1>
+        <p className="text-muted-foreground text-center">Customize your experience here.</p>
+      </main>
+    </MobileLayout>
+  );
+}

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,4 +1,5 @@
 import { ChatInterface } from "@/components/chat/chat-interface";
+import MobileLayout from '../../components/MobileLayout'
 
 /**
  * The main page of the Euromesh application.
@@ -6,8 +7,10 @@ import { ChatInterface } from "@/components/chat/chat-interface";
  */
 export default function Home() {
   return (
-      <main className="flex min-h-screen items-center justify-center bg-zinc-900 p-4">
-        <ChatInterface />
-      </main>
+      <MobileLayout>
+        <div className="flex min-h-screen items-center justify-center bg-zinc-900 p-4">
+          <ChatInterface />
+        </div>
+      </MobileLayout>
   );
 }

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -1,25 +1,28 @@
 'use client'
 import { QRCodeSVG } from 'qrcode.react'
+import MobileLayout from '../../components/MobileLayout'
 
 export default function WalletPage() {
-  const name = "John Doe"; // placeholder name
+  const name = "Alex Müller";
   const qrValue = `passport-${Math.random().toString(36).slice(2)}`;
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4 bg-background text-foreground">
-      <div className="bg-card text-card-foreground rounded-xl shadow-md p-6 w-full max-w-sm space-y-4">
-        <h1 className="text-center text-xl font-semibold">Digital Wallet</h1>
-        <div className="text-center">
-          <p className="text-sm">Name</p>
-          <p className="font-medium text-lg">{name}</p>
+    <MobileLayout>
+      <div className="min-h-screen flex items-center justify-center p-4 bg-background text-foreground">
+        <div className="bg-card text-card-foreground rounded-xl shadow-md p-6 w-full max-w-sm space-y-4">
+          <h1 className="text-center text-xl font-semibold">Digital Wallet</h1>
+          <div className="text-center">
+            <p className="text-sm">Name</p>
+            <p className="font-medium text-lg">{name}</p>
+          </div>
+          <div className="flex justify-center">
+            <QRCodeSVG value={qrValue} size={180} level="Q" />
+          </div>
+          <p className="text-xs text-center text-muted-foreground">
+            Present this QR code as a one-time passport
+          </p>
         </div>
-        <div className="flex justify-center">
-          <QRCodeSVG value={qrValue} size={180} level="Q" />
-        </div>
-        <p className="text-xs text-center text-muted-foreground">
-          Present this QR code as a one-time passport
-        </p>
       </div>
-    </div>
+    </MobileLayout>
   )
 }

--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { MapPin, MessageCircle, ListChecks, Rss, Settings, Home } from 'lucide-react'; // Example icons
+import { MessageCircle, ListChecks, Rss, Settings, Home, Wallet } from 'lucide-react';
 import { cn } from "@/lib/utils"; // shadcn/ui utility
 
 interface NavItem {
@@ -12,10 +12,11 @@ interface NavItem {
 }
 
 const navItems: NavItem[] = [
-    { href: '/', label: 'Map', icon: Home }, // Assuming Map is the home page
+    { href: '/', label: 'Map', icon: Home },
+    { href: '/news', label: 'News', icon: Rss },
+    { href: '/chatbot', label: 'Chatbot', icon: MessageCircle },
+    { href: '/wallet', label: 'Wallet', icon: Wallet },
     { href: '/faq', label: 'FAQ', icon: ListChecks },
-    { href: '/chatbot', label: 'Chat', icon: MessageCircle },
-    { href: '/liveticker', label: 'Ticker', icon: Rss },
     { href: '/settings', label: 'Settings', icon: Settings },
 ];
 
@@ -43,7 +44,7 @@ export default function MobileLayout({ children }: MobileLayoutProps) {
             </main>
 
             <nav className="fixed bottom-0 left-0 right-0 z-50 h-16 border-t bg-background shadow-t-lg">
-                <div className="mx-auto grid h-full max-w-lg grid-cols-5 font-medium">
+                <div className="mx-auto grid h-full max-w-lg grid-cols-6 font-medium">
                     {navItems.map((item) => {
                         const isActive = (pathname === '/' && item.href === '/') || (item.href !== '/' && pathname.startsWith(item.href));
                         return (

--- a/src/services/googlePlaces.ts
+++ b/src/services/googlePlaces.ts
@@ -28,7 +28,12 @@ export async function getGermanEmbassiesNearby(city: string, country: string): P
       return [];
     }
 
-    return data.results.map((place: any) => ({
+    return data.results.map((place: {
+      name: string;
+      formatted_address: string;
+      geometry: { location: { lat: number; lng: number } };
+      place_id: string;
+    }) => ({
       name: place.name,
       formatted_address: place.formatted_address,
       geometry: {


### PR DESCRIPTION
## Summary
- wrap existing pages with `MobileLayout` so bottom navigation appears
- add real example name in the wallet page
- create new pages: **chatbot**, **liveticker**, and **settings**
- update `MobileLayout` navigation links for all pages
- type Google Places service to satisfy lint rules

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856a5a6f280832f8a91ded5da6e90c7