### PR TITLE
Extend map page to handle landmarks and areas

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,9 @@
 // src/app/page.tsx
 
-"use client";
-
-import * as React from "react";
-import Map, { Source, Layer } from "react-map-gl/maplibre";
-import { motion, AnimatePresence } from "framer-motion";
 import type { FeatureCollection } from "geojson";
-import "maplibre-gl/dist/maplibre-gl.css";
-
-import { Button } from "@/components/ui/button";
-import {SystemStatus} from "@/types/status";
-import {CrisisWarningOverlay} from "@/components/crising-warning-oerlay";
-import {MapOverlay} from "@/components/map-overlay";
-
-// Retrieve MapTiler key from environment variables
-const MAPTILER_KEY = process.env.NEXT_PUBLIC_MAPTILER_KEY_LOCAL;
-if (!MAPTILER_KEY) {
-    throw new Error("Missing NEXT_PUBLIC_MAPTILER_KEY environment variable.");
-}
+import { InteractiveMap } from "@/components/interactive-map";
+import type { Landmark } from "@/types/landmarks";
+import type { Area } from "@/types/areas";
 
 // Example restriction zones (centered on initial view at lon: 51.3347, lat: 35.7219)
 const restrictionZone: FeatureCollection = {
@@ -59,78 +45,31 @@ const restrictionZone: FeatureCollection = {
   ]
 };
 
-/**
- * The main page component, featuring a full-screen map and a sleek UI overlay.
- * It manages the application's system status and applies conditional effects.
- *
- * @returns {React.ReactElement} The rendered home page.
- */
-export default function Home(): React.ReactElement {
-    const [status, setStatus] = React.useState<SystemStatus>("Online");
+const sampleLandmarks: Landmark[] = [
+  {
+    id: "checkpoint-a",
+    name: "Checkpoint A",
+    location: { lat: 35.722, lng: 51.335 },
+    category: "checkpoint",
+  },
+  {
+    id: "medical-1",
+    name: "Medical Center",
+    location: { lat: 35.725, lng: 51.34 },
+    category: "medical",
+  },
+];
 
-    const [isCrisisAcknowledged, setIsCrisisAcknowledged] = React.useState(false);
+const sampleAreas: Area[] = [
+  {
+    id: "restriction",
+    name: "Restriction Zones",
+    geometry: restrictionZone,
+    category: "no_go",
+  },
+];
 
-    React.useEffect(() => {
-        if (status !== 'Crisis') {
-            setIsCrisisAcknowledged(false);
-        }
-    }, [status]);
-
-    return (
-        <main className="relative h-screen w-screen overflow-hidden bg-black">
-            <AnimatePresence>
-                {status === 'Crisis' && !isCrisisAcknowledged && (
-                    <CrisisWarningOverlay onAcknowledge={() => setIsCrisisAcknowledged(true)} />
-                )}
-            </AnimatePresence>
-            {/*
-        This div is a dedicated layer for the glow effect.
-        - `absolute inset-0`: Covers the entire parent.
-        - `z-10`: Sits above the map (default z-index 0).
-        - `pointer-events-none`: Allows clicks to pass through to the map below.
-        - `MapOverlay` has a `z-index` of 10, so this glow will be layered correctly.
-      */}
-            <motion.div
-                className="pointer-events-none absolute inset-0 z-10"
-                animate={{
-                    boxShadow:
-                        status === "Transmitting"
-                            ? "inset 0px 0px 20px 5px rgba(59, 130, 246, 0.6)" // blue-500
-                            : "inset 0px 0px 0px 0px rgba(59, 130, 246, 0)",
-                }}
-                transition={{ duration: 0.8, ease: "easeInOut" }}
-            />
-
-            <Map
-                initialViewState={{ longitude: 51.3347, latitude: 35.7219, zoom: 12 }}
-                mapStyle={`https://api.maptiler.com/maps/streets-v2/style.json?key=${MAPTILER_KEY}`}
-                style={{ position: "absolute", inset: 0, width: '100%', height: '100%' }}
-            >
-                <Source id="zone-source" type="geojson" data={restrictionZone}>
-                    <Layer
-                        id="zone-fill"
-                        type="fill"
-                        paint={{ "fill-color": "#DC2626", "fill-opacity": 0.25 }}
-                    />
-                    <Layer
-                        id="zone-outline"
-                        type="line"
-                        paint={{ "line-color": "#DC2626", "line-width": 2 }}
-                    />
-                </Source>
-            </Map>
-
-            {/* The UI Overlay sits on top of the map and the glow effect layer */}
-            <MapOverlay status={status} />
-
-            {/* DEV CONTROLS: For demonstrating status changes. Remove in production. */}
-            <div className="absolute bottom-24 right-4 z-20 flex flex-col gap-2">
-                {(["Online", "Transmitting", "Crisis", "Offline"] as SystemStatus[]).map((s) => (
-                    <Button key={s} onClick={() => setStatus(s)} size="sm" variant="secondary">
-                        Set: {s}
-                    </Button>
-                ))}
-            </div>
-        </main>
-    );
+export default function Home() {
+  return <InteractiveMap landmarks={sampleLandmarks} areas={sampleAreas} />;
 }
+

--- a/src/components/interactive-map.tsx
+++ b/src/components/interactive-map.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import * as React from "react";
+import Map, { Source, Layer } from "react-map-gl/maplibre";
+import { motion, AnimatePresence } from "framer-motion";
+import "maplibre-gl/dist/maplibre-gl.css";
+
+import { Button } from "@/components/ui/button";
+import { MapOverlay } from "@/components/map-overlay";
+import { CrisisWarningOverlay } from "@/components/crising-warning-oerlay";
+import { MapMarker } from "@/components/map-marker";
+import { SystemStatus } from "@/types/status";
+import type { Landmark } from "@/types/landmarks";
+import type { Area } from "@/types/areas";
+
+interface InteractiveMapProps {
+    landmarks?: Landmark[];
+    areas?: Area[];
+}
+
+export function InteractiveMap({ landmarks = [], areas = [] }: InteractiveMapProps): React.ReactElement {
+    const [status, setStatus] = React.useState<SystemStatus>("Online");
+    const [isCrisisAcknowledged, setIsCrisisAcknowledged] = React.useState(false);
+
+    React.useEffect(() => {
+        if (status !== "Crisis") {
+            setIsCrisisAcknowledged(false);
+        }
+    }, [status]);
+
+    const MAPTILER_KEY = process.env.NEXT_PUBLIC_MAPTILER_KEY_LOCAL;
+    if (!MAPTILER_KEY) {
+        throw new Error("Missing NEXT_PUBLIC_MAPTILER_KEY environment variable.");
+    }
+
+    return (
+        <main className="relative h-screen w-screen overflow-hidden bg-black">
+            <AnimatePresence>
+                {status === "Crisis" && !isCrisisAcknowledged && (
+                    <CrisisWarningOverlay onAcknowledge={() => setIsCrisisAcknowledged(true)} />
+                )}
+            </AnimatePresence>
+
+            <motion.div
+                className="pointer-events-none absolute inset-0 z-10"
+                animate={{
+                    boxShadow:
+                        status === "Transmitting"
+                            ? "inset 0px 0px 20px 5px rgba(59, 130, 246, 0.6)"
+                            : "inset 0px 0px 0px 0px rgba(59, 130, 246, 0)",
+                }}
+                transition={{ duration: 0.8, ease: "easeInOut" }}
+            />
+
+            <Map
+                initialViewState={{ longitude: 51.3347, latitude: 35.7219, zoom: 12 }}
+                mapStyle={`https://api.maptiler.com/maps/streets-v2/style.json?key=${MAPTILER_KEY}`}
+                style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
+            >
+                {areas.map((area) => (
+                    <Source key={area.id} id={`area-${area.id}`} type="geojson" data={area.geometry}>
+                        <Layer
+                            id={`area-fill-${area.id}`}
+                            type="fill"
+                            paint={{ "fill-color": area.fillColor || "#DC2626", "fill-opacity": 0.25 }}
+                        />
+                        <Layer
+                            id={`area-outline-${area.id}`}
+                            type="line"
+                            paint={{ "line-color": area.borderColor || "#DC2626", "line-width": 2 }}
+                        />
+                    </Source>
+                ))}
+
+                {landmarks.map((lm) => (
+                    <MapMarker key={lm.id} latitude={lm.location.lat} longitude={lm.location.lng}>
+                        <div title={lm.name} className="h-4 w-4 -translate-y-1 rounded-full border-2 border-white bg-blue-600 shadow" />
+                    </MapMarker>
+                ))}
+            </Map>
+
+            <MapOverlay status={status} />
+
+            <div className="absolute bottom-24 right-4 z-20 flex flex-col gap-2">
+                {(["Online", "Transmitting", "Crisis", "Offline"] as SystemStatus[]).map((s) => (
+                    <Button key={s} onClick={() => setStatus(s)} size="sm" variant="secondary">
+                        Set: {s}
+                    </Button>
+                ))}
+            </div>
+        </main>
+    );
+}

--- a/src/types/areas.ts
+++ b/src/types/areas.ts
@@ -1,0 +1,10 @@
+export type AreaCategory = 'no_go' | 'caution' | 'safe';
+
+export interface Area {
+    id: string;
+    name: string;
+    geometry: GeoJSON.FeatureCollection;
+    category: AreaCategory;
+    fillColor?: string;
+    borderColor?: string;
+}


### PR DESCRIPTION
## Summary
- create `Area` type for zone polygons
- build `InteractiveMap` component that renders landmarks and areas
- update main map page to pass sample data to `InteractiveMap`

## Testing
- `npm run lint`
- `NEXT_PUBLIC_MAPTILER_KEY_LOCAL=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856b38b1e78832f99ee70735ca904a1