### PR TITLE
Add animated map route support

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 // src/app/page.tsx
 
-import type { FeatureCollection } from "geojson";
+import type { FeatureCollection, LineString } from "geojson";
 import { InteractiveMap } from "@/components/interactive-map";
 import type { Landmark } from "@/types/landmarks";
 import type { Area } from "@/types/areas";
@@ -69,7 +69,24 @@ const sampleAreas: Area[] = [
   },
 ];
 
+const sampleRoute: LineString = {
+  type: "LineString",
+  coordinates: [
+    [51.33, 35.72],
+    [51.335, 35.723],
+    [51.34, 35.726],
+    [51.345, 35.729],
+    [51.35, 35.732],
+  ],
+};
+
 export default function Home() {
-  return <InteractiveMap landmarks={sampleLandmarks} areas={sampleAreas} />;
+  return (
+    <InteractiveMap
+      landmarks={sampleLandmarks}
+      areas={sampleAreas}
+      route={sampleRoute}
+    />
+  );
 }
 

--- a/src/components/animated-route.tsx
+++ b/src/components/animated-route.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React from "react";
+import { Source, Layer } from "react-map-gl/maplibre";
+import type { LineString } from "geojson";
+import { MapMarker } from "@/components/map-marker";
+
+export interface AnimatedRouteProps {
+    /** GeoJSON LineString for the route */
+    route: LineString;
+    /** Animation duration in milliseconds */
+    duration?: number;
+}
+
+export function AnimatedRoute({ route, duration = 10000 }: AnimatedRouteProps): React.ReactElement {
+    const coordinates = route.coordinates;
+    const [position, setPosition] = React.useState(coordinates[0]);
+
+    React.useEffect(() => {
+        if (coordinates.length < 2) return;
+        let frame: number;
+        const start = performance.now();
+
+        const step = () => {
+            const now = performance.now();
+            const progress = Math.min((now - start) / duration, 1);
+            const distance = progress * (coordinates.length - 1);
+            const idx = Math.floor(distance);
+            const t = distance - idx;
+            const [lng1, lat1] = coordinates[idx];
+            const [lng2, lat2] = coordinates[Math.min(idx + 1, coordinates.length - 1)];
+            const lng = lng1 + (lng2 - lng1) * t;
+            const lat = lat1 + (lat2 - lat1) * t;
+            setPosition([lng, lat]);
+            if (progress < 1) {
+                frame = requestAnimationFrame(step);
+            }
+        };
+
+        frame = requestAnimationFrame(step);
+        return () => cancelAnimationFrame(frame);
+    }, [coordinates, duration]);
+
+    return (
+        <>
+            <Source
+                id="animated-route"
+                type="geojson"
+                data={{ type: "Feature", geometry: route, properties: {} }}
+            >
+                <Layer id="animated-route-line" type="line" paint={{ "line-width": 5, "line-color": "#2563EB" }} />
+            </Source>
+            <MapMarker longitude={position[0]} latitude={position[1]}>
+                <div className="h-3 w-3 -translate-y-1 rounded-full border-2 border-white bg-red-600 shadow" />
+            </MapMarker>
+        </>
+    );
+}

--- a/src/components/interactive-map.tsx
+++ b/src/components/interactive-map.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import Map, { Source, Layer } from "react-map-gl/maplibre";
+import type { LineString } from "geojson";
 import { motion, AnimatePresence } from "framer-motion";
 import "maplibre-gl/dist/maplibre-gl.css";
 
@@ -9,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { MapOverlay } from "@/components/map-overlay";
 import { CrisisWarningOverlay } from "@/components/crising-warning-oerlay";
 import { MapMarker } from "@/components/map-marker";
+import { AnimatedRoute } from "@/components/animated-route";
 import { SystemStatus } from "@/types/status";
 import type { Landmark } from "@/types/landmarks";
 import type { Area } from "@/types/areas";
@@ -16,9 +18,11 @@ import type { Area } from "@/types/areas";
 interface InteractiveMapProps {
     landmarks?: Landmark[];
     areas?: Area[];
+    /** Optional route to display and animate */
+    route?: LineString;
 }
 
-export function InteractiveMap({ landmarks = [], areas = [] }: InteractiveMapProps): React.ReactElement {
+export function InteractiveMap({ landmarks = [], areas = [], route }: InteractiveMapProps): React.ReactElement {
     const [status, setStatus] = React.useState<SystemStatus>("Online");
     const [isCrisisAcknowledged, setIsCrisisAcknowledged] = React.useState(false);
 
@@ -77,6 +81,8 @@ export function InteractiveMap({ landmarks = [], areas = [] }: InteractiveMapPro
                         <div title={lm.name} className="h-4 w-4 -translate-y-1 rounded-full border-2 border-white bg-blue-600 shadow" />
                     </MapMarker>
                 ))}
+
+                {route && <AnimatedRoute route={route} />}
             </Map>
 
             <MapOverlay status={status} />


### PR DESCRIPTION
## Summary
- animate a marker along a predefined route
- allow `InteractiveMap` to accept an optional route and render `AnimatedRoute`
- showcase animated route in the home page

## Testing
- `NEXT_PUBLIC_MAPTILER_KEY_LOCAL=dummy npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856b6728b44832fb45d5418e00dc245