### PR TITLE
Allow dynamic map updates via hooks

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,8 @@
 // src/app/page.tsx
 
+"use client";
+
+import * as React from "react";
 import type { FeatureCollection, LineString } from "geojson";
 import { InteractiveMap } from "@/components/interactive-map";
 import type { Landmark } from "@/types/landmarks";
@@ -81,12 +84,55 @@ const sampleRoute: LineString = {
 };
 
 export default function Home() {
+  const [landmarks, setLandmarks] = React.useState<Landmark[]>(sampleLandmarks);
+  const [areas, setAreas] = React.useState<Area[]>(sampleAreas);
+
+  const addLandmark = () => {
+    setLandmarks((prev) => [
+      ...prev,
+      {
+        id: `dynamic-lm-${prev.length}`,
+        name: `Landmark ${prev.length}`,
+        location: { lat: 35.72 + prev.length * 0.002, lng: 51.335 },
+        category: "checkpoint",
+      },
+    ]);
+  };
+
+  const addArea = () => {
+    setAreas((prev) => [
+      ...prev,
+      {
+        id: `dynamic-area-${prev.length}`,
+        name: `Area ${prev.length}`,
+        geometry: restrictionZone,
+        category: "caution",
+      },
+    ]);
+  };
+
   return (
-    <InteractiveMap
-      landmarks={sampleLandmarks}
-      areas={sampleAreas}
-      route={sampleRoute}
-    />
+    <>
+      <InteractiveMap
+        landmarks={landmarks}
+        areas={areas}
+        route={sampleRoute}
+      />
+      <div className="absolute top-4 left-4 z-20 flex flex-col gap-2">
+        <button
+          onClick={addLandmark}
+          className="rounded bg-blue-600 px-3 py-2 text-white"
+        >
+          Add Landmark
+        </button>
+        <button
+          onClick={addArea}
+          className="rounded bg-blue-600 px-3 py-2 text-white"
+        >
+          Add Area
+        </button>
+      </div>
+    </>
   );
 }
 

--- a/src/components/landmark-marker.tsx
+++ b/src/components/landmark-marker.tsx
@@ -143,7 +143,11 @@ export function LandmarkMarker({ landmark }: LandmarkMarkerProps): React.ReactEl
         try {
             return formatDistanceToNow(new Date(isoDate), { addSuffix: true });
         } catch (error) {
-            console.error("Invalid date format for lastUpdated:", isoDate);
+            console.error(
+                "Invalid date format for lastUpdated:",
+                isoDate,
+                error
+            );
             return "unknown";
         }
     };

--- a/src/lib/actions/gemini.ts
+++ b/src/lib/actions/gemini.ts
@@ -72,7 +72,10 @@ export async function getGeminiResponse(
     landmarks = JSON.parse(fileContent);
     console.log(`Loaded ${landmarks.length} landmarks from mesh database.`);
   } catch (error) {
-    console.log("No mesh database found or it's empty. Starting with a clean context.");
+    console.log(
+      "No mesh database found or it's empty. Starting with a clean context.",
+      error
+    );
   }
 
   const historyForPrompt = chatHistory


### PR DESCRIPTION
## Summary
- convert homepage to client component
- store `landmarks` and `areas` in React state
- add temporary buttons to add sample landmarks or areas
- fix lint warnings on unused errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856bd86c0b4832fa97ed96e73fcd578