### PR TITLE
Expand map data sources

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,52 +3,27 @@
 "use client";
 
 import * as React from "react";
-import type { FeatureCollection, LineString } from "geojson";
+import type { LineString } from "geojson";
 import { InteractiveMap } from "@/components/interactive-map";
 import type { Area } from "@/types/areas";
-import {Landmark} from "@/lib/types";
-import defaultLandmarks from "../../data/landmarks.json";
+import { Landmark } from "@/lib/types";
+import checkpoint from "../../data/checkpoint.json";
+import communication from "../../data/communication.json";
+import dangerousSpots from "../../data/dangerous_spot.json";
+import hospitals from "../../data/hospitals.json";
+import medical from "../../data/medical.json";
+import safeSpaces from "../../data/safe_space.json";
 import defaultAreas from "../../data/areas.json";
 
-// Example restriction zones (centered on initial view at lon: 51.3347, lat: 35.7219)
-const restrictionZone: FeatureCollection = {
-  type: "FeatureCollection",
-  features: [
-    {
-      type: "Feature",
-      properties: { name: "No‑Go Zone" },
-      geometry: {
-        type: "Polygon",
-        coordinates: [
-          [
-            [51.33, 35.70],
-            [51.33, 35.745],
-            [51.35, 35.75],
-            [51.355, 35.72],
-            [51.345, 35.695],
-            [51.33, 35.70]
-          ]
-        ]
-      }
-    },
-    {
-      type: "Feature",
-      properties: { name: "Caution Zone" },
-      geometry: {
-        type: "Polygon",
-        coordinates: [
-          [
-            [51.32, 35.71],
-            [51.34, 35.74],
-            [51.36, 35.71],
-            [51.34, 35.68],
-            [51.32, 35.71]
-          ]
-        ]
-      }
-    }
-  ]
-};
+const defaultLandmarks: Landmark[] = [
+  ...(checkpoint as Landmark[]),
+  ...(communication as Landmark[]),
+  ...(dangerousSpots as Landmark[]),
+  ...(hospitals as Landmark[]),
+  ...(medical as Landmark[]),
+  ...(safeSpaces as Landmark[]),
+];
+
 
 
 // --- REVISED AND IMPROVED ROUTE ---
@@ -81,10 +56,10 @@ export default function Home() {
       if (storedLandmarks) {
         setLandmarks(JSON.parse(storedLandmarks));
       } else {
-        setLandmarks(defaultLandmarks as Landmark[]);
+        setLandmarks(defaultLandmarks);
       }
     } catch {
-      setLandmarks(defaultLandmarks as Landmark[]);
+      setLandmarks(defaultLandmarks);
     }
 
     try {
@@ -112,30 +87,6 @@ export default function Home() {
     }
   }, [areas]);
 
-  const addLandmark = () => {
-    setLandmarks((prev) => [
-      ...prev,
-      {
-        id: `dynamic-lm-${prev.length}`,
-        name: `Landmark ${prev.length}`,
-        location: { lat: 35.72 + prev.length * 0.002, lng: 51.335 },
-        category: "checkpoint",
-      },
-    ]);
-  };
-
-  const addArea = () => {
-    setAreas((prev) => [
-      ...prev,
-      {
-        id: `dynamic-area-${prev.length}`,
-        name: `Area ${prev.length}`,
-        geometry: restrictionZone,
-        category: "caution",
-        description: "User added area",
-      },
-    ]);
-  };
 
   return (
     <>

--- a/src/components/landmark-marker.tsx
+++ b/src/components/landmark-marker.tsx
@@ -54,9 +54,9 @@ const landmarkConfig: Record<
             badge: "bg-green-500/20 text-green-300 border-green-400/30",
         },
     },
-    danger_zone: {
+    dangerous_spot: {
         icon: Siren,
-        label: "Danger Zone",
+        label: "Dangerous Spot",
         styles: {
             bg: "bg-red-600",
             text: "text-red-100",
@@ -84,9 +84,9 @@ const landmarkConfig: Record<
             badge: "bg-yellow-500/20 text-yellow-300 border-yellow-400/30",
         },
     },
-    satellite_phone: {
+    communication: {
         icon: RadioTower,
-        label: "Satellite Phone",
+        label: "Communication",
         styles: {
             bg: "bg-indigo-600",
             text: "text-indigo-100",

--- a/src/lib/actions/gemini.ts
+++ b/src/lib/actions/gemini.ts
@@ -36,7 +36,7 @@ You are the AI engine for the Euromesh emergency app. You have two primary modes
 
 2.  **REPORT_MODE:**
     *   **Trigger:** The user wants to report a danger.
-    *   **Action:** Your goal is to create a 'danger_zone' landmark by collecting a 'name' and a 'description'. Follow this procedure:
+    *   **Action:** Your goal is to create a 'dangerous_spot' landmark by collecting a 'name' and a 'description'. Follow this procedure:
         1.  Analyze the user's message and the conversation history.
         2.  Check if you have extracted BOTH a specific 'name' (the place) AND a 'description' (what happened).
         3.  **If BOTH are present**, return a \`report\` type JSON.

--- a/src/lib/actions/mesh.ts
+++ b/src/lib/actions/mesh.ts
@@ -20,7 +20,7 @@ export async function saveReportToMesh(
             name: reportPayload.name,
             description: reportPayload.description,
             location: userLocation,
-            category: 'danger_zone',
+            category: 'dangerous_spot',
             trustLevel: 'low',
             isVerified: false,
             addedBy: 'user_report',


### PR DESCRIPTION
## Summary
- load landmarks from all new JSON datasets
- remove unused functions and zone example from page.tsx
- align landmark categories with data
- adjust server actions for `dangerous_spot`

## Testing
- `npm run lint`
- `npm run build` *(fails: Missing `NEXT_PUBLIC_MAPTILER_KEY`)*

------
https://chatgpt.com/codex/tasks/task_e_6856c9d644bc832fafac610881768deb