### PR TITLE
Fix duplicate landmark keys

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,6 @@ import type { Area } from "@/types/areas";
 import { Landmark } from "@/lib/types";
 import type { Route } from "@/types/routes";
 import defaultLandmarks from "../../data/landmarks.json";
-import type { LineString } from "geojson";
 import checkpoint from "../../data/checkpoint.json";
 import communication from "../../data/communication.json";
 import dangerousSpots from "../../data/dangerous_spot.json";

--- a/src/components/interactive-map.tsx
+++ b/src/components/interactive-map.tsx
@@ -68,6 +68,16 @@ export function InteractiveMap({ landmarks = [], areas = [], routes = [], route 
         [areas, routes]
     );
 
+    // Filter out any duplicate landmarks by ID to avoid React key conflicts
+    const uniqueLandmarks = React.useMemo(() => {
+        const seen = new Set<string>();
+        return landmarks.filter((lm) => {
+            if (seen.has(lm.id)) return false;
+            seen.add(lm.id);
+            return true;
+        });
+    }, [landmarks]);
+
     const handleMapClick = React.useCallback(
         (e: maplibregl.MapLayerMouseEvent) => {
             if (!e.features || e.features.length === 0) {
@@ -154,7 +164,7 @@ export function InteractiveMap({ landmarks = [], areas = [], routes = [], route 
                     );
                 })}
 
-                {landmarks.map((lm) => (
+                {uniqueLandmarks.map((lm) => (
                     <LandmarkMarker key={lm.id} landmark={lm} />
                 ))}
 


### PR DESCRIPTION
## Summary
- ensure landmark keys are unique by filtering duplicates in `InteractiveMap`
- remove an unused import in `page.tsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856cf4294dc832fae0ce07b9afb1a47