### PR TITLE
Handle location requests

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -70,7 +70,8 @@ export function ChatInterface() {
                 switch (assistantResponse.type) {
                     case 'message':
                         let content = assistantResponse.payload.content;
-                        if (content.toLowerCase().includes('location')) {
+                        const locationRequestRegex = /(location|where|address|place|map)/i;
+                        if (locationRequestRegex.test(content)) {
                             setShowLocationPicker(true);
                             content = 'Please select the location on the map.';
                         }
@@ -89,6 +90,16 @@ export function ChatInterface() {
                             id: crypto.randomUUID(),
                             role: 'assistant',
                             content: "Thank you. Your report has been received and will be shared with the network.",
+                        };
+                        setMessages(prev => [...prev, finalAssistantMessage]);
+                        break;
+
+                    case 'location_request':
+                        setShowLocationPicker(true);
+                        finalAssistantMessage = {
+                            id: crypto.randomUUID(),
+                            role: 'assistant',
+                            content: assistantResponse.payload.content,
                         };
                         setMessages(prev => [...prev, finalAssistantMessage]);
                         break;

--- a/src/lib/actions/gemini.ts
+++ b/src/lib/actions/gemini.ts
@@ -41,6 +41,7 @@ You are the AI engine for the Euromesh emergency app. You have two primary modes
         2.  Check if you have extracted BOTH a specific 'name' (the place) AND a 'description' (what happened).
         3.  **If BOTH are present**, return a \`report\` type JSON.
         4.  **If EITHER 'name' OR 'description' is missing**, you MUST return a \`message\` type JSON to ask the user for the missing information.
+        5.  **If you need the user's location**, return a \`location_request\` type JSON asking them to share it.
     *   **JSON Output (when complete):** \`{"type": "report", "payload": {"name": "...", "description": "..."}}\`
 
 --- RULES & EXAMPLES ---
@@ -56,7 +57,12 @@ You are the AI engine for the Euromesh emergency app. You have two primary modes
   - User: "A bridge collapsed."
   - Your JSON Response: \`{"type": "message", "payload": {"content": "Thank you. Can you tell me the location or name of the collapsed bridge?"}}\`
 
+- **Example 3: Requesting Location**
+  - User: "A fire broke out near me."
+  - Your JSON Response: \`{"type": "location_request", "payload": {"content": "Please share your location."}}\`
+
 - **Example 3: Complete Report (All details provided over two turns)**
+- **Example 4: Complete Report (All details provided over two turns)**
   - (After the previous exchange)
   - User: "It's the Tabiat Bridge."
   - Your JSON Response: \`{"type": "report", "payload": {"name": "Tabiat Bridge", "description": "A bridge collapsed"}}\`
@@ -118,3 +124,4 @@ ${historyForPrompt}
     return { success: true, data: errorResponse };
   }
 }
+

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -46,7 +46,7 @@ export interface Message {
  * A discriminated union representing all possible structured responses from the LLM.
  * The 'type' field allows the client to route the response to the correct handler.
  */
-export type AssistantResponse = MessageResponse | ReportResponse;
+export type AssistantResponse = MessageResponse | ReportResponse | LocationRequestResponse;
 
 /**
  * The structure for a standard conversational message from the AI.
@@ -74,3 +74,14 @@ export interface ReportResponse {
     type: "report";
     payload: ReportPayload;
 }
+
+/**
+ * A special response requesting the user's precise location.
+ */
+export interface LocationRequestResponse {
+    type: "location_request";
+    payload: {
+        content: string;
+    };
+}
+


### PR DESCRIPTION
## Summary
- allow chat UI to handle `location_request` responses from the AI
- include location request examples and instructions in the prompt

## Testing
- `npm run lint`
- `npm run build` *(fails: Missing `NEXT_PUBLIC_MAPTILER_KEY`)*

------
https://chatgpt.com/codex/tasks/task_e_6856cea64c10832f9ecaad1110f3da79