### PR TITLE
Move route and status controls into debug menu

### DIFF
--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -1,5 +1,4 @@
 "use client"
-import { Button } from "@/components/ui/button"
 import MobileLayout from '../../components/MobileLayout'
 
 export default function DebugPage() {
@@ -7,17 +6,7 @@ export default function DebugPage() {
     <MobileLayout>
       <div className="p-8 space-y-4">
         <h1 className="text-2xl font-semibold">Debug Tools</h1>
-        <div className="flex flex-wrap gap-2">
-          <Button id="button-one" onClick={() => alert("asdasdasd")}>Button One</Button>
-          <Button id="button-two">Button Two</Button>
-          <Button id="button-three">Button Three</Button>
-        </div>
-        <section
-          id="debug-output"
-          className="mt-4 p-4 border rounded min-h-[100px]"
-        >
-          Debug output will appear here.
-        </section>
+        <p>Use the floating debug menu (Shift+D) to toggle routes and set status.</p>
       </div>
     </MobileLayout>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import DebugMenu from "@/components/DebugMenu";
 import { LocationProvider } from "@/lib/state/location";
+import { DebugProvider } from "@/lib/state/debug";
 import {TooltipProvider} from "@/components/ui/tooltip";
 
 const geistSans = Geist({
@@ -29,10 +30,12 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <LocationProvider>
-          <TooltipProvider delayDuration={150}>
-          {children}
-          <DebugMenu />
-          </TooltipProvider>
+          <DebugProvider>
+            <TooltipProvider delayDuration={150}>
+              {children}
+              <DebugMenu />
+            </TooltipProvider>
+          </DebugProvider>
         </LocationProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,12 +4,11 @@
 
 import * as React from "react";
 import { InteractiveMap } from "@/components/interactive-map";
-import { Button } from "@/components/ui/button";
 import type { Area } from "@/types/areas";
 import { Landmark } from "@/lib/types";
 import type { Route } from "@/types/routes";
 import importedLandmarks from "../../data/landmarks.json";
-import type { LineString } from "geojson";
+import { useDebug } from "@/lib/state/debug";
 import checkpoint from "../../data/checkpoint.json";
 import communication from "../../data/communication.json";
 import dangerousSpots from "../../data/dangerous_spot.json";
@@ -19,8 +18,6 @@ import safeSpaces from "../../data/safe_space.json";
 
 import defaultAreas from "../../data/areas.json";
 import defaultRoutes from "../../data/routes.json";
-import animatedRouteA from "../../data/animated_route.json";
-import animatedRouteB from "../../data/animated_route_alt.json";
 
 const defaultLandmarks: Landmark[] = [
   ...(importedLandmarks as Landmark[]),
@@ -39,7 +36,7 @@ export default function Home() {
   const [landmarks, setLandmarks] = React.useState<Landmark[]>([]);
   const [areas, setAreas] = React.useState<Area[]>([]);
   const [routes, setRoutes] = React.useState<Route[]>([]);
-  const [route, setRoute] = React.useState<LineString | null>(null);
+  const { route } = useDebug();
 
   // Load default data and any stored user data on first render
   React.useEffect(() => {
@@ -76,16 +73,6 @@ export default function Home() {
       setRoutes(defaultRoutes as Route[]);
     }
 
-    try {
-      const storedRoute = localStorage.getItem('animatedRoute');
-      if (storedRoute) {
-        setRoute(JSON.parse(storedRoute));
-      } else {
-        setRoute(animatedRouteA as LineString);
-      }
-    } catch {
-      setRoute(animatedRouteA as LineString);
-    }
   }, []);
 
   // Persist landmarks and areas whenever they change
@@ -108,11 +95,6 @@ export default function Home() {
     }
   }, [routes]);
 
-  React.useEffect(() => {
-    if (route) {
-      localStorage.setItem('animatedRoute', JSON.stringify(route));
-    }
-  }, [route]);
 
 
   return (
@@ -123,21 +105,7 @@ export default function Home() {
         routes={routes}
         route={route ?? undefined}
       />
-      <div className="absolute bottom-4 left-4 z-20">
-        <Button
-          onClick={() =>
-            setRoute((current) =>
-              current && JSON.stringify(current) === JSON.stringify(animatedRouteA)
-                ? (animatedRouteB as LineString)
-                : (animatedRouteA as LineString)
-            )
-          }
-          variant="secondary"
-          size="sm"
-        >
-          Change Route
-        </Button>
-      </div>
+
     </>
   );
 }

--- a/src/components/DebugMenu.tsx
+++ b/src/components/DebugMenu.tsx
@@ -1,6 +1,11 @@
 "use client";
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useCallback, useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
+import { useDebug } from "@/lib/state/debug";
+import animatedRouteA from "../../data/animated_route.json";
+import animatedRouteB from "../../data/animated_route_alt.json";
+import type { LineString } from "geojson";
+import type { SystemStatus } from "@/types/status";
 
 interface DebugAction {
   key: string;
@@ -8,28 +13,34 @@ interface DebugAction {
   handler: () => void;
 }
 
-const actions: DebugAction[] = [
-  {
-    key: "1",
-    label: "Action One",
-    handler: () => console.log("Action one executed"),
-  },
-  {
-    key: "2",
-    label: "Action Two",
-    handler: () => console.log("Action two executed"),
-  },
-  {
-    key: "3",
-    label: "Action Three",
-    handler: () => console.log("Action three executed"),
-  },
-];
-
 export default function DebugMenu() {
   const [open, setOpen] = useState(false);
+  const { setStatus, setRoute } = useDebug();
 
   const toggle = useCallback(() => setOpen((o) => !o), []);
+
+  const actions = useMemo<DebugAction[]>(
+    () => [
+      {
+        key: "r",
+        label: "Toggle Route (R)",
+        handler: () =>
+          setRoute((current) =>
+            current && JSON.stringify(current) === JSON.stringify(animatedRouteA)
+              ? (animatedRouteB as LineString)
+              : (animatedRouteA as LineString)
+          ),
+      },
+      ...(["Online", "Transmitting", "Crisis", "Offline"] as SystemStatus[]).map(
+        (s, idx) => ({
+          key: String(idx + 1),
+          label: `Set Status: ${s}`,
+          handler: () => setStatus(s),
+        })
+      ),
+    ],
+    [setRoute, setStatus]
+  );
 
   const handleKey = useCallback(
     (e: KeyboardEvent) => {
@@ -45,7 +56,7 @@ export default function DebugMenu() {
         }
       });
     },
-    [toggle]
+    [toggle, actions]
   );
 
   useEffect(() => {

--- a/src/components/interactive-map.tsx
+++ b/src/components/interactive-map.tsx
@@ -8,7 +8,6 @@ import circle from "@turf/circle";
 import { motion, AnimatePresence } from "framer-motion";
 import "maplibre-gl/dist/maplibre-gl.css";
 
-import { Button } from "@/components/ui/button";
 import { MapOverlay } from "@/components/map-overlay";
 import { CrisisWarningOverlay } from "@/components/crising-warning-oerlay";
 import { LandmarkMarker } from "@/components/landmark-marker";
@@ -17,7 +16,7 @@ import { RoutePath } from "@/components/route-path";
 import { useLocation } from "@/lib/state/location";
 import { AreaPopup } from "@/components/area-popup";
 import { RoutePopup } from "@/components/route-popup";
-import { SystemStatus } from "@/types/status";
+import { useDebug } from "@/lib/state/debug";
 import type { Area, AreaCategory } from "@/types/areas";
 const CATEGORY_COLORS: Record<AreaCategory, { fill: string; border: string }> = {
     no_go: { fill: "#DC2626", border: "#b91c1c" },
@@ -49,19 +48,10 @@ interface InteractiveMapProps {
 }
 
 export function InteractiveMap({ landmarks = [], areas = [], routes = [], route }: InteractiveMapProps): React.ReactElement {
-    const [status, setStatus] = React.useState<SystemStatus>("Online");
+    const { status } = useDebug();
     const [isCrisisAcknowledged, setIsCrisisAcknowledged] = React.useState(false);
 
     const { lastKnownLocation } = useLocation();
-    const [viewState, setViewState] = React.useState({
-        longitude: lastKnownLocation.lng,
-        latitude: lastKnownLocation.lat,
-        zoom: 12,
-    });
-
-    React.useEffect(() => {
-        setViewState((vs) => ({ ...vs, longitude: lastKnownLocation.lng, latitude: lastKnownLocation.lat }));
-    }, [lastKnownLocation]);
     const [selectedArea, setSelectedArea] = React.useState<{
         area: Area;
         coordinates: { lng: number; lat: number };
@@ -175,7 +165,6 @@ export function InteractiveMap({ landmarks = [], areas = [], routes = [], route 
 
             <Map
                 initialViewState={{ longitude: lastKnownLocation.lng, latitude: lastKnownLocation.lat, zoom: 12 }}
-                onMove={(e) => setViewState(e.viewState)}
                 mapStyle={`https://api.maptiler.com/maps/streets-v2/style.json?key=${MAPTILER_KEY}`}
                 style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
                 onClick={handleMapClick}
@@ -237,14 +226,6 @@ export function InteractiveMap({ landmarks = [], areas = [], routes = [], route 
             </Map>
 
             <MapOverlay status={status} landmarks={landmarks} areas={areas} />
-
-            <div className="absolute bottom-24 right-4 z-20 flex flex-col gap-2">
-                {(["Online", "Transmitting", "Crisis", "Offline"] as SystemStatus[]).map((s) => (
-                    <Button key={s} onClick={() => setStatus(s)} size="sm" variant="secondary">
-                        Set: {s}
-                    </Button>
-                ))}
-            </div>
         </main>
     );
 }

--- a/src/lib/state/debug.tsx
+++ b/src/lib/state/debug.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { createContext, useContext, useState, useEffect, ReactNode } from "react";
+import type { SystemStatus } from "@/types/status";
+import type { LineString } from "geojson";
+import animatedRouteA from "../../../data/animated_route.json";
+
+interface DebugContextType {
+  status: SystemStatus;
+  setStatus: (s: SystemStatus) => void;
+  route: LineString | null;
+  setRoute: (r: LineString | null) => void;
+}
+
+const DebugContext = createContext<DebugContextType | undefined>(undefined);
+
+export function DebugProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<SystemStatus>("Online");
+  const [route, setRoute] = useState<LineString | null>(animatedRouteA as LineString);
+
+  useEffect(() => {
+    try {
+      const storedStatus = localStorage.getItem("systemStatus");
+      if (storedStatus) setStatus(storedStatus as SystemStatus);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    if (status) localStorage.setItem("systemStatus", status);
+  }, [status]);
+
+  useEffect(() => {
+    try {
+      const storedRoute = localStorage.getItem("animatedRoute");
+      if (storedRoute) setRoute(JSON.parse(storedRoute));
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    if (route) localStorage.setItem("animatedRoute", JSON.stringify(route));
+  }, [route]);
+
+  return (
+    <DebugContext.Provider value={{ status, setStatus, route, setRoute }}>
+      {children}
+    </DebugContext.Provider>
+  );
+}
+
+export function useDebug() {
+  const ctx = useContext(DebugContext);
+  if (!ctx) {
+    throw new Error("useDebug must be used within DebugProvider");
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- introduce `DebugProvider` context for global status/route management
- wire provider into layout so pages and debug menu share state
- move change route and set status actions into `DebugMenu`
- clean up interactive map and home page to use context
- simplify debug page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856dd127f2c832f9793263f210b9fe6