### PR TITLE
Add landmark creation flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@google/generative-ai": "^0.24.1",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-avatar": "^1.1.10",
+        "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-scroll-area": "^1.2.9",
         "@radix-ui/react-select": "^2.2.5",
@@ -1322,6 +1323,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-scroll-area": "^1.2.9",
+    "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -114,6 +114,10 @@ export default function Home() {
     }
   }, [route]);
 
+  const handleAddLandmark = React.useCallback((lm: Landmark) => {
+    setLandmarks((prev) => [...prev, lm]);
+  }, []);
+
 
   return (
     <>
@@ -122,6 +126,7 @@ export default function Home() {
         areas={areas}
         routes={routes}
         route={route ?? undefined}
+        onAddLandmark={handleAddLandmark}
       />
       <div className="absolute bottom-4 left-4 z-20">
         <Button

--- a/src/components/add-info-button.tsx
+++ b/src/components/add-info-button.tsx
@@ -11,6 +11,10 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { SelectMap } from "@/components/select-map";
+import { LandmarkDialog } from "@/components/landmark-dialog";
+import { useLocation } from "@/lib/state/location";
+import type { Landmark } from "@/lib/types";
 
 /**
  * An icon button to allow users to add new information to the map.
@@ -20,29 +24,64 @@ import {
  *
  * @returns {React.ReactElement} The rendered "Add Info" button.
  */
-export function AddInfoButton(): React.ReactElement {
+interface AddInfoButtonProps {
+    onAdd?: (lm: Landmark) => void;
+}
+
+export function AddInfoButton({ onAdd }: AddInfoButtonProps): React.ReactElement {
+    const { lastKnownLocation } = useLocation();
+    const [showPicker, setShowPicker] = React.useState(false);
+    const [dialogOpen, setDialogOpen] = React.useState(false);
+    const [picked, setPicked] = React.useState(lastKnownLocation);
+
+    const handleMapSave = (loc: { lat: number; lng: number }) => {
+        setPicked(loc);
+        setShowPicker(false);
+        setDialogOpen(true);
+    };
+
+    const handleAdd = (lm: Landmark) => {
+        onAdd?.(lm);
+    };
+
     return (
-        <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, ease: "easeInOut", delay: 0.1 }}
-            className="pointer-events-auto"
-        >
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <Button
-                        variant="default"
-                        size="icon"
-                        className="h-12 w-12 rounded-full bg-black/50 shadow-lg backdrop-blur-sm hover:bg-black/70"
-                        aria-label="Add Information to Map"
-                    >
-                        <Plus className="h-6 w-6 text-white" />
-                    </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top" className="bg-black/70 text-white border-none">
-                    <p>Add Information</p>
-                </TooltipContent>
-            </Tooltip>
-        </motion.div>
+        <>
+            <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, ease: "easeInOut", delay: 0.1 }}
+                className="pointer-events-auto"
+            >
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            variant="default"
+                            size="icon"
+                            onClick={() => setShowPicker(true)}
+                            className="h-12 w-12 rounded-full bg-black/50 shadow-lg backdrop-blur-sm hover:bg-black/70"
+                            aria-label="Add Information to Map"
+                        >
+                            <Plus className="h-6 w-6 text-white" />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="bg-black/70 text-white border-none">
+                        <p>Add Information</p>
+                    </TooltipContent>
+                </Tooltip>
+            </motion.div>
+
+            {showPicker && (
+                <div className="fixed inset-0 z-50 bg-black">
+                    <SelectMap onSave={handleMapSave} className="h-full w-full" />
+                </div>
+            )}
+
+            <LandmarkDialog
+                open={dialogOpen}
+                onOpenChange={setDialogOpen}
+                location={picked}
+                onSubmit={handleAdd}
+            />
+        </>
     );
 }

--- a/src/components/interactive-map.tsx
+++ b/src/components/interactive-map.tsx
@@ -46,14 +46,15 @@ interface InteractiveMapProps {
     routes?: Route[];
     /** Optional route to display and animate */
     route?: LineString;
+    onAddLandmark?: (lm: Landmark) => void;
 }
 
-export function InteractiveMap({ landmarks = [], areas = [], routes = [], route }: InteractiveMapProps): React.ReactElement {
+export function InteractiveMap({ landmarks = [], areas = [], routes = [], route, onAddLandmark }: InteractiveMapProps): React.ReactElement {
     const [status, setStatus] = React.useState<SystemStatus>("Online");
     const [isCrisisAcknowledged, setIsCrisisAcknowledged] = React.useState(false);
 
     const { lastKnownLocation } = useLocation();
-    const [viewState, setViewState] = React.useState({
+    const [, setViewState] = React.useState({
         longitude: lastKnownLocation.lng,
         latitude: lastKnownLocation.lat,
         zoom: 12,
@@ -236,7 +237,7 @@ export function InteractiveMap({ landmarks = [], areas = [], routes = [], route 
                 )}
             </Map>
 
-            <MapOverlay status={status} landmarks={landmarks} areas={areas} />
+            <MapOverlay status={status} landmarks={landmarks} areas={areas} onAddLandmark={onAddLandmark} />
 
             <div className="absolute bottom-24 right-4 z-20 flex flex-col gap-2">
                 {(["Online", "Transmitting", "Crisis", "Offline"] as SystemStatus[]).map((s) => (

--- a/src/components/landmark-dialog.tsx
+++ b/src/components/landmark-dialog.tsx
@@ -1,0 +1,100 @@
+"use client";
+import * as React from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import type { Landmark, LandmarkCategory } from "@/lib/types";
+
+interface LandmarkDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  location: { lat: number; lng: number };
+  onSubmit: (lm: Landmark) => void;
+}
+
+const categories: LandmarkCategory[] = [
+  "safe_space",
+  "dangerous_spot",
+  "communication",
+  "trusted_contact",
+  "medical",
+  "checkpoint",
+];
+
+export function LandmarkDialog({ open, onOpenChange, location, onSubmit }: LandmarkDialogProps) {
+  const [name, setName] = React.useState("");
+  const [description, setDescription] = React.useState("");
+  const [category, setCategory] = React.useState<LandmarkCategory>("safe_space");
+  const [radius, setRadius] = React.useState("");
+
+  const handleSubmit = () => {
+    const landmark: Landmark = {
+      id: crypto.randomUUID(),
+      name,
+      description: description || undefined,
+      category,
+      location,
+      radius: radius ? parseFloat(radius) : undefined,
+    };
+    onSubmit(landmark);
+    onOpenChange(false);
+    setName("");
+    setDescription("");
+    setRadius("");
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Landmark</DialogTitle>
+          <DialogDescription>Provide details for the new landmark.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <Input placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Description"
+            className="min-h-[60px] w-full rounded-md border border-neutral-700 bg-black/50 p-2 text-white"
+          />
+          <Select value={category} onValueChange={(v) => setCategory(v as LandmarkCategory)}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Category" />
+            </SelectTrigger>
+            <SelectContent>
+              {categories.map((c) => (
+                <SelectItem key={c} value={c} className="capitalize">
+                  {c.replace(/_/g, " ")}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            type="number"
+            placeholder="Radius (meters)"
+            value={radius}
+            onChange={(e) => setRadius(e.target.value)}
+          />
+        </div>
+        <DialogFooter>
+          <Button onClick={handleSubmit}>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/map-overlay.tsx
+++ b/src/components/map-overlay.tsx
@@ -19,6 +19,7 @@ interface MapOverlayProps {
     status: SystemStatus;
     landmarks: Landmark[];
     areas: Area[];
+    onAddLandmark?: (lm: Landmark) => void;
 }
 
 /**
@@ -29,7 +30,7 @@ interface MapOverlayProps {
  * @param {MapOverlayProps} props - The component props.
  * @returns {React.ReactElement} The rendered map overlay.
  */
-export function MapOverlay({ status, landmarks, areas }: MapOverlayProps): React.ReactElement {
+export function MapOverlay({ status, landmarks, areas, onAddLandmark }: MapOverlayProps): React.ReactElement {
     const [searchActive, setSearchActive] = React.useState(false);
     const [filter, setFilter] = React.useState<"all" | "landmarks" | "areas">("all");
 
@@ -70,7 +71,7 @@ export function MapOverlay({ status, landmarks, areas }: MapOverlayProps): React
             ) : (
                 <footer className="flex w-full items-center justify-center">
                     <div className="flex items-center justify-center gap-2 sm:gap-4">
-                        <AddInfoButton />
+                        <AddInfoButton onAdd={onAddLandmark} />
                         {searchBar}
                         <ChatbotButton />
                     </div>

--- a/src/components/select-map.tsx
+++ b/src/components/select-map.tsx
@@ -6,13 +6,15 @@ import { MapPin } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { MapMarker } from "@/components/map-marker";
 import { useLocation } from "@/lib/state/location";
+import { cn } from "@/lib/utils";
 
 interface SelectMapProps {
-    onSave?: () => void;
+    onSave?: (loc: { lat: number; lng: number }) => void;
     zoom?: number;
+    className?: string;
 }
 
-export function SelectMap({ onSave, zoom = 12 }: SelectMapProps) {
+export function SelectMap({ onSave, zoom = 12, className }: SelectMapProps) {
     const { lastKnownLocation, setLastKnownLocation } = useLocation();
     const [selected, setSelected] = React.useState(lastKnownLocation);
 
@@ -28,11 +30,11 @@ export function SelectMap({ onSave, zoom = 12 }: SelectMapProps) {
 
     const handleSave = () => {
         setLastKnownLocation(selected);
-        onSave?.();
+        onSave?.(selected);
     };
 
     return (
-        <div className="relative h-72 w-full">
+        <div className={cn("relative h-72 w-full", className)}>
             <Map
                 initialViewState={{ longitude: lastKnownLocation.lng, latitude: lastKnownLocation.lat, zoom }}
                 mapStyle={`https://api.maptiler.com/maps/streets-v2/style.json?key=${MAPTILER_KEY}`}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,86 @@
+"use client";
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/70 backdrop-blur-sm",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-neutral-700 bg-black p-6 text-white shadow-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100 focus:outline-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />;
+}
+DialogHeader.displayName = "DialogHeader";
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />;
+}
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-gray-300", className)} {...props} />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogPrimitive as DialogPrimitivePackage,
+};


### PR DESCRIPTION
## Summary
- allow selecting a map spot and entering landmark details
- connect add button to map picker and dialog
- propagate new landmark callback through overlay and map
- expose shadcn dialog component
- support customizing SelectMap
- include `@radix-ui/react-dialog` dependency

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856dddc3b08832fba203723cbc8fd14