### PR TITLE
Keep search bar in footer

### DIFF
--- a/src/components/interactive-map.tsx
+++ b/src/components/interactive-map.tsx
@@ -53,7 +53,7 @@ export function InteractiveMap({ landmarks = [], areas = [], routes = [], route 
     const [isCrisisAcknowledged, setIsCrisisAcknowledged] = React.useState(false);
 
     const { lastKnownLocation } = useLocation();
-    const [viewState, setViewState] = React.useState({
+    const [, setViewState] = React.useState({
         longitude: lastKnownLocation.lng,
         latitude: lastKnownLocation.lat,
         zoom: 12,

--- a/src/components/map-overlay.tsx
+++ b/src/components/map-overlay.tsx
@@ -49,33 +49,25 @@ export function MapOverlay({ status, landmarks, areas }: MapOverlayProps): React
             className="pointer-events-none fixed inset-0 z-20 flex flex-col justify-between p-4 sm:p-6"
             aria-hidden="true"
         >
-            {!searchActive && (
-                <header className="relative flex w-full items-start justify-center">
-                    <div className="absolute left-0 top-0">
-                        <MapLegend />
-                    </div>
-                    <div className="pt-1">
-                        <StatusIndicator status={status} />
-                    </div>
-                    <div className="absolute right-0 top-0">
-                        <MainMenu />
-                    </div>
-                </header>
-            )}
-
-            {searchActive ? (
-                <div className="pointer-events-auto absolute left-0 right-0 top-4 flex flex-col items-center gap-2">
-                    {searchBar}
+            <header className="relative flex w-full items-start justify-center">
+                <div className="absolute left-0 top-0">
+                    <MapLegend />
                 </div>
-            ) : (
-                <footer className="flex w-full items-center justify-center">
-                    <div className="flex items-center justify-center gap-2 sm:gap-4">
-                        <AddInfoButton />
-                        {searchBar}
-                        <ChatbotButton />
-                    </div>
-                </footer>
-            )}
+                <div className="pt-1">
+                    <StatusIndicator status={status} />
+                </div>
+                <div className="absolute right-0 top-0">
+                    <MainMenu />
+                </div>
+            </header>
+
+            <footer className="flex w-full items-center justify-center">
+                <div className="flex items-center justify-center gap-2 sm:gap-4">
+                    <AddInfoButton />
+                    {searchBar}
+                    <ChatbotButton />
+                </div>
+            </footer>
         </div>
     );
 }

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -118,31 +118,38 @@ export function SearchBar({
                 className="h-12 w-full rounded-full border-none bg-black/50 pl-11 pr-4 text-white shadow-lg backdrop-blur-sm placeholder:text-gray-400 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-0"
             />
             {active && (
-                <div className="absolute left-0 right-0 top-full z-10 mt-2 flex flex-col gap-2">
-                    <Select value={filter} onValueChange={(v: string) => onFilterChange?.(v as "all" | "landmarks" | "areas")}>
-                        <SelectTrigger className="w-full">
-                            <SelectValue placeholder="Filter" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            <SelectItem value="all">All</SelectItem>
-                            <SelectItem value="landmarks">Landmarks</SelectItem>
-                            <SelectItem value="areas">Areas</SelectItem>
-                        </SelectContent>
-                    </Select>
+                <>
+                    <div className="absolute left-0 right-0 bottom-full z-10 mb-2">
+                        <Select
+                            value={filter}
+                            onValueChange={(v: string) => onFilterChange?.(v as "all" | "landmarks" | "areas")}
+                        >
+                            <SelectTrigger className="w-full">
+                                <SelectValue placeholder="Filter" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="all">All</SelectItem>
+                                <SelectItem value="landmarks">Landmarks</SelectItem>
+                                <SelectItem value="areas">Areas</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
                     {results.length > 0 && (
-                        <ScrollArea className="max-h-40 rounded-md bg-black/80 text-white shadow-lg backdrop-blur-sm">
-                            {results.map((r) => (
-                                <button
-                                    key={`${r.type}-${r.id}`}
-                                    onClick={() => handleSelect(r)}
-                                    className="block w-full px-3 py-2 text-left hover:bg-black/60"
-                                >
-                                    {r.name}
-                                </button>
-                            ))}
-                        </ScrollArea>
+                        <div className="absolute left-0 right-0 top-full z-10 mt-2">
+                            <ScrollArea className="max-h-40 rounded-md bg-black/80 text-white shadow-lg backdrop-blur-sm">
+                                {results.map((r) => (
+                                    <button
+                                        key={`${r.type}-${r.id}`}
+                                        onClick={() => handleSelect(r)}
+                                        className="block w-full px-3 py-2 text-left hover:bg-black/60"
+                                    >
+                                        {r.name}
+                                    </button>
+                                ))}
+                            </ScrollArea>
+                        </div>
                     )}
-                </div>
+                </>
             )}
         </motion.div>
     );


### PR DESCRIPTION
## Summary
- keep the map overlay header visible even when the search bar is active
- keep the search bar fixed in the footer
- show filter menu above the search input
- silence lint error in `interactive-map`

## Testing
- `npm run lint`
- `npm run build` *(fails: Missing NEXT_PUBLIC_MAPTILER_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_6856de4d07a4832faa513e575cce2695