### PR TITLE
Add new debug menu actions

### DIFF
--- a/data/landmark_change.json
+++ b/data/landmark_change.json
@@ -1,0 +1,13 @@
+{
+  "id": "debug-landmark",
+  "name": "Temporary Safe Spot",
+  "location": {"lat": 35.728, "lng": 51.342},
+  "radius": 100,
+  "category": "safe_space",
+  "description": "Debug landmark for route change",
+  "trustLevel": "high",
+  "lastUpdated": "2025-06-21T00:00:00Z",
+  "addedBy": "debug",
+  "isVerified": true,
+  "visible": true
+}

--- a/src/components/DebugMenu.tsx
+++ b/src/components/DebugMenu.tsx
@@ -2,8 +2,10 @@
 import { useEffect, useCallback, useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { useDebug } from "@/lib/state/debug";
+import { useLandmarks } from "@/lib/state/landmarks";
 import animatedRouteA from "../../data/animated_route.json";
 import animatedRouteB from "../../data/animated_route_alt.json";
+import landmarkChange from "../../data/landmark_change.json";
 import type { LineString } from "geojson";
 import type { SystemStatus } from "@/types/status";
 
@@ -16,6 +18,7 @@ interface DebugAction {
 export default function DebugMenu() {
   const [open, setOpen] = useState(false);
   const { setStatus, setRoute } = useDebug();
+  const { addLandmark } = useLandmarks();
 
   const toggle = useCallback(() => setOpen((o) => !o), []);
 
@@ -31,6 +34,19 @@ export default function DebugMenu() {
               : (animatedRouteA as LineString)
           ),
       },
+      {
+        key: "q",
+        label: "Start Route 1 (Q)",
+        handler: () => setRoute(animatedRouteA as LineString),
+      },
+      {
+        key: "w",
+        label: "Start Landmark Change (W)",
+        handler: () => {
+          addLandmark(landmarkChange);
+          setRoute(animatedRouteB as LineString);
+        },
+      },
       ...(["Online", "Transmitting", "Crisis", "Offline"] as SystemStatus[]).map(
         (s, idx) => ({
           key: String(idx + 1),
@@ -39,7 +55,7 @@ export default function DebugMenu() {
         })
       ),
     ],
-    [setRoute, setStatus]
+    [addLandmark, setRoute, setStatus]
   );
 
   const handleKey = useCallback(

--- a/src/lib/state/debug.tsx
+++ b/src/lib/state/debug.tsx
@@ -3,7 +3,6 @@ import {
   createContext,
   useContext,
   useState,
-  useEffect,
   ReactNode,
 } from "react";
 


### PR DESCRIPTION
## Summary
- create `landmark_change.json` containing a sample landmark for debug
- add `Start Route 1` and `Start Landmark Change` actions to `DebugMenu`
- clean unused import in debug state to satisfy lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856f2833824832fb704e1c6e65ba80d