### PR TITLE
Fix debug landmark initialization

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,22 +20,6 @@ export default function Home() {
 
   // Load default data on first render
   React.useEffect(() => {
-    async function loadLandmarks() {
-      try {
-        const res = await fetch("/api/landmarks");
-        if (res.ok) {
-          const dynamic: Landmark[] = await res.json();
-          setLandmarks([...dynamic, ...staticLandmarks]);
-        } else {
-          setLandmarks([...staticLandmarks]);
-        }
-      } catch {
-        setLandmarks([...staticLandmarks]);
-      }
-    }
-
-    void loadLandmarks();
-
     setAreas(defaultAreas as Area[]);
     setRoutes(defaultRoutes as Route[]);
   }, []);

--- a/src/components/DebugMenu.tsx
+++ b/src/components/DebugMenu.tsx
@@ -6,6 +6,7 @@ import { useLandmarks } from "@/lib/state/landmarks";
 import animatedRouteA from "../../data/animated_route.json";
 import animatedRouteB from "../../data/animated_route_alt.json";
 import landmarkChange from "../../data/landmark_change.json";
+import type { Landmark } from "@/lib/types";
 import type { LineString } from "geojson";
 import type { SystemStatus } from "@/types/status";
 
@@ -43,7 +44,7 @@ export default function DebugMenu() {
         key: "w",
         label: "Start Landmark Change (W)",
         handler: () => {
-          addLandmark(landmarkChange);
+          addLandmark(landmarkChange as Landmark);
           setRoute(animatedRouteB as LineString);
         },
       },

--- a/src/lib/state/landmarks.tsx
+++ b/src/lib/state/landmarks.tsx
@@ -39,18 +39,21 @@ export function LandmarksProvider({ children }: { children: ReactNode }) {
       try {
         const stored = localStorage.getItem("landmarks");
         if (stored) {
-          setLandmarks(JSON.parse(stored));
+          const loaded = JSON.parse(stored) as Landmark[];
+          setLandmarks((prev) => (prev.length ? prev : loaded));
           return;
         }
         const res = await fetch("/api/landmarks");
         if (res.ok) {
           const dynamic: Landmark[] = await res.json();
-          setLandmarks([...dynamic, ...staticLandmarks]);
+          const loaded = [...dynamic, ...staticLandmarks];
+          setLandmarks((prev) => (prev.length ? prev : loaded));
         } else {
-          setLandmarks([...staticLandmarks]);
+          const loaded = [...staticLandmarks];
+          setLandmarks((prev) => (prev.length ? prev : loaded));
         }
       } catch {
-        setLandmarks([...staticLandmarks]);
+        setLandmarks((prev) => (prev.length ? prev : [...staticLandmarks]));
       }
     }
     void loadLandmarks();


### PR DESCRIPTION
## Summary
- keep landmarks added before async load
- remove stray landmark setup code
- ensure debug landmark casts to correct type

## Testing
- `npm run lint`
- `NEXT_PUBLIC_MAPTILER_KEY_LOCAL=foobar npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856f89a65ec832f88313db849d85818