### PR TITLE
Clean up comments and docstrings

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,7 +3,7 @@
 "use client";
 
 import * as React from "react";
-import { motion, type Variants } from "framer-motion"; // ✅ FIX: Import the 'Variants' type
+import { motion, type Variants } from "framer-motion";
 import { Bell, Palette, Lock, Info, LogOut } from "lucide-react";
 import MobileLayout from '../../components/MobileLayout';
 import { Switch } from "@/components/ui/switch";
@@ -30,7 +30,7 @@ export default function SettingsPage(): React.ReactElement {
     const [mapStyle, setMapStyle] = React.useState<string>("streets-v2");
 
     // --- Animation Variants with Explicit Typing ---
-    const containerVariants: Variants = { // ✅ FIX: Explicitly apply the 'Variants' type
+    const containerVariants: Variants = {
         hidden: { opacity: 0 },
         visible: {
             opacity: 1,
@@ -38,7 +38,7 @@ export default function SettingsPage(): React.ReactElement {
         },
     };
 
-    const itemVariants: Variants = { // ✅ FIX: Explicitly apply the 'Variants' type
+    const itemVariants: Variants = {
         hidden: { opacity: 0, x: -20 },
         visible: { opacity: 1, x: 0, transition: { type: 'spring', stiffness: 100 } },
     };

--- a/src/components/chatbot-button.tsx
+++ b/src/components/chatbot-button.tsx
@@ -15,16 +15,13 @@ import clsx from "clsx";
 
 // --- UI Component Imports ---
 import {Avatar, AvatarFallback} from "@/components/ui/avatar";
-// --- UI Component Imports ---
 import {Button} from "@/components/ui/button";
 import {Input} from "@/components/ui/input";
 import {ScrollArea} from "@/components/ui/scroll-area";
-import {SelectMap} from "@/components/select-map"; // Updated Import
-// --- Logic and Type Imports ---
-// --- Logic and Type Imports ---
+import {SelectMap} from "@/components/select-map";
 import {getGeminiResponse} from "@/lib/actions/gemini";
 import {saveReportToMesh} from "@/lib/actions/mesh";
-import type { Location, Message, ReportPayload } from "@/lib/types"; // Ensure Location type is exported
+import type { Location, Message, ReportPayload } from "@/lib/types";
 import {cn} from "@/lib/utils";
 import {useLocation} from "@/lib/state/location";
 import { useLandmarks } from "@/lib/state/landmarks";

--- a/src/components/map-legend.tsx
+++ b/src/components/map-legend.tsx
@@ -24,15 +24,9 @@ export function MapLegend(): React.ReactElement {
             <AnimatePresence>
                 {isOpen && (
                     <motion.div
-                        // --- THIS IS THE CRITICAL FIX ---
-                        // 'absolute': Positions the popup relative to the container above.
-                        // 'top-full': Pushes the popup's TOP edge to the BOTTOM of the container (i.e., below the button).
-                        // 'left-0': Aligns the popup's LEFT edge with the LEFT edge of the container.
-                        // 'mt-2': Adds a small gap between the button and the popup.
-                        // 'origin-top-left': Ensures the 'scale' animation grows from the top-left corner.
+                        /* Position the popup below the toggle button */
                         className="absolute top-full left-0 mt-2 w-48 origin-top-left rounded-lg border border-neutral-700 bg-black/70 p-3 shadow-xl backdrop-blur-md"
 
-                        // Animation now correctly moves downwards.
                         initial={{ opacity: 0, y: -10, scale: 0.95 }}
                         animate={{ opacity: 1, y: 0, scale: 1 }}
                         exit={{ opacity: 0, y: -10, scale: 0.95 }}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -18,9 +18,9 @@ export type GeminiApiResponse = ApiResponse<AssistantResponse>;
 // --- Core Data & Domain Types ---
 
 /**
- * **THE MISSING TYPE IS HERE.**
- * Represents a generic JSON document provided as context to the AI. This is used
- * in getGeminiResponse to allow for a flexible mix of structured and unstructured data.
+ * Represents a generic JSON document used as context for the AI engine.
+ * This allows for a flexible mix of structured and unstructured data in
+ * the {@link getGeminiResponse} function.
  */
 export type ContextDocument = Record<string, unknown>;
 


### PR DESCRIPTION
## Summary
- trim extraneous notes in `MapLegend`
- remove leftover `FIX` comments from settings page
- drop outdated notes in chatbot button imports
- clarify `ContextDocument` description

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685705663ad4832fb578cb2b9b570ba4