### PR TITLE
Fix comments and add missing docstrings

### DIFF
--- a/src/app/emergency-call/page.tsx
+++ b/src/app/emergency-call/page.tsx
@@ -1,4 +1,6 @@
-// src/app/emergency-call/page.tsx
+/**
+ * Page providing emergency call instructions.
+ */
 
 "use client";
 

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,4 +1,6 @@
-// src/app/faq/page.tsx
+/**
+ * FAQ page with common questions and answers.
+ */
 
 import type { Metadata } from 'next';
 import faqStaticData from './faq-data.json';

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,4 +1,6 @@
-// src/app/news/page.tsx
+/**
+ * News feed displaying recent updates.
+ */
 
 "use client";
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
-// src/app/page.tsx
+/**
+ * Home page displaying the interactive map.
+ */
 
 "use client";
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,4 +1,6 @@
-// src/app/settings/page.tsx
+/**
+ * User settings page.
+ */
 
 "use client";
 

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -1,4 +1,6 @@
-// src/app/wallet/page.tsx
+/**
+ * Digital wallet demo page.
+ */
 
 "use client";
 

--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -1,4 +1,6 @@
-// src/components/MobileLayout.tsx
+/**
+ * Mobile-friendly layout with bottom navigation.
+ */
 
 "use client";
 

--- a/src/components/add-info-button.tsx
+++ b/src/components/add-info-button.tsx
@@ -1,4 +1,6 @@
-// src/components/add-info-button.tsx
+/**
+ * Floating button to submit new map information.
+ */
 
 "use client";
 

--- a/src/components/animated-route.tsx
+++ b/src/components/animated-route.tsx
@@ -1,4 +1,6 @@
-// src/components/animated-route.tsx
+/**
+ * Animates a route being drawn on the map.
+ */
 
 "use client";
 

--- a/src/components/area-popup.tsx
+++ b/src/components/area-popup.tsx
@@ -1,4 +1,6 @@
-// src/components/area-popup.tsx
+/**
+ * Map popup displayed when selecting an area.
+ */
 
 "use client";
 

--- a/src/components/crisis-warning-overlay.tsx
+++ b/src/components/crisis-warning-overlay.tsx
@@ -1,4 +1,3 @@
-// src/components/crisis-warning-overlay.tsx
 
 "use client";
 

--- a/src/components/faq-page-content.tsx
+++ b/src/components/faq-page-content.tsx
@@ -1,4 +1,6 @@
-// src/components/faq-page-content.tsx
+/**
+ * Interactive FAQ content component.
+ */
 
 "use client"; // This directive now lives here.
 

--- a/src/components/interactive-map.tsx
+++ b/src/components/interactive-map.tsx
@@ -9,7 +9,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import "maplibre-gl/dist/maplibre-gl.css";
 
 import { MapOverlay } from "@/components/map-overlay";
-import { CrisisWarningOverlay } from "@/components/crising-warning-oerlay";
+import { CrisisWarningOverlay } from "@/components/crisis-warning-overlay";
 import { LandmarkMarker } from "@/components/landmark-marker";
 import { AnimatedRoute } from "@/components/animated-route";
 import { RoutePath } from "@/components/route-path";

--- a/src/components/landmark-marker.tsx
+++ b/src/components/landmark-marker.tsx
@@ -1,4 +1,6 @@
-// src/components/landmark-marker.tsx
+/**
+ * Marker with detailed popover for a single landmark.
+ */
 
 "use client";
 

--- a/src/components/main-menu.tsx
+++ b/src/components/main-menu.tsx
@@ -1,5 +1,7 @@
+/**
+ * Responsive popover menu for navigation links.
+ */
 
-// src/components/main-menu.tsx
 
 "use client";
 

--- a/src/components/map-legend.tsx
+++ b/src/components/map-legend.tsx
@@ -1,4 +1,6 @@
-// src/components/map-legend.tsx
+/**
+ * Collapsible legend explaining map area categories.
+ */
 
 "use client";
 

--- a/src/components/map-marker.tsx
+++ b/src/components/map-marker.tsx
@@ -1,4 +1,6 @@
-// src/components/map-marker.tsx
+/**
+ * Thin wrapper around map markers.
+ */
 
 "use client";
 

--- a/src/components/map-overlay.tsx
+++ b/src/components/map-overlay.tsx
@@ -1,4 +1,6 @@
-// src/components/map-overlay.tsx
+/**
+ * Overlay showing map controls and status indicators.
+ */
 
 import * as React from "react";
 import { ChatbotButton } from "./chatbot-button";

--- a/src/components/news-card.tsx
+++ b/src/components/news-card.tsx
@@ -1,4 +1,6 @@
-// src/components/news-card.tsx
+/**
+ * Card component for displaying news items.
+ */
 
 "use client";
 

--- a/src/components/route-layout.tsx
+++ b/src/components/route-layout.tsx
@@ -1,5 +1,7 @@
+/**
+ * Experimental map view showing a sample route layer.
+ */
 
-// src/components/route-layout.tsx
 'use client';
 import { useState, useEffect } from 'react';
 import Map, { Source, Layer } from 'react-map-gl/maplibre'; // works identically with Mapbox

--- a/src/components/route-path.tsx
+++ b/src/components/route-path.tsx
@@ -1,4 +1,6 @@
-// src/components/route-path.tsx
+/**
+ * Static route polyline display.
+ */
 "use client";
 
 import * as React from "react";

--- a/src/components/route-popup.tsx
+++ b/src/components/route-popup.tsx
@@ -1,4 +1,6 @@
-// src/components/route-popup.tsx
+/**
+ * Popup showing details about a route.
+ */
 "use client";
 
 import * as React from "react";

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -1,4 +1,6 @@
-// src/components/search-bar.tsx
+/**
+ * Location and area search bar component.
+ */
 
 "use client";
 

--- a/src/components/status-indicator.tsx
+++ b/src/components/status-indicator.tsx
@@ -1,4 +1,6 @@
-// src/components/status-indicator.tsx
+/**
+ * Visual indicator for system status.
+ */
 
 "use client";
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,4 +1,6 @@
-// src/components/ui/button.tsx
+/**
+ * UI button with multiple styling variants.
+ */
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,4 +1,6 @@
-// src/components/ui/tooltip.tsx
+/**
+ * Wrapper components around Radix tooltip primitives.
+ */
 
 "use client"
 

--- a/src/utils/landmarkAdapters.ts
+++ b/src/utils/landmarkAdapters.ts
@@ -1,4 +1,8 @@
-// src/utils/landmarkAdapters.ts
+/**
+ * Convert a Google Places result to a Landmark record.
+ * @param place Raw result from Google Places.
+ * @returns Simplified landmark data.
+ */
 import { RawPlaceResult } from '../services/googlePlaces';
 import { Landmark } from '../lib/types/landmarks';
 


### PR DESCRIPTION
## Summary
- remove path comments from many files
- rename misspelled overlay component
- add short docstrings to various components and pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685709aed458832f8963d4400bd725d2