### PR TITLE
Update debug menu hotkey

### DIFF
--- a/src/components/DebugMenu.tsx
+++ b/src/components/DebugMenu.tsx
@@ -67,7 +67,7 @@ export default function DebugMenu() {
 
   const handleKey = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key.toLowerCase() === "d" && e.shiftKey) {
+      if (e.key.toLowerCase() === "d" && e.metaKey) {
         e.preventDefault();
         toggle();
         return;
@@ -89,7 +89,7 @@ export default function DebugMenu() {
 
   return (
     <div className="fixed bottom-4 right-4 z-50">
-      {open ? (
+      {open && (
         <div className="bg-popover text-popover-foreground border rounded shadow-lg p-4 space-y-2">
           {actions.map((action) => (
             <Button key={action.key} onClick={action.handler} className="w-full">
@@ -97,13 +97,9 @@ export default function DebugMenu() {
             </Button>
           ))}
           <Button variant="secondary" onClick={toggle} className="w-full">
-            Close (Shift+D)
+            Close (⌘D)
           </Button>
         </div>
-      ) : (
-        <Button size="icon" onClick={toggle} aria-label="Open debug menu">
-          D
-        </Button>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- hide debug menu toggle button and show menu only with `⌘D`
- update close button label
- change hotkey listener to use the Command key

## Testing
- `npm run lint` *(fails: 'LandmarkCategory' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_6857d470df0c832f9f23e6f28599c435