### PR TITLE
Update route start logic

### DIFF
--- a/src/components/DebugMenu.tsx
+++ b/src/components/DebugMenu.tsx
@@ -3,6 +3,7 @@ import { useEffect, useCallback, useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { useDebug } from "@/lib/state/debug";
 import { useLandmarks } from "@/lib/state/landmarks";
+import { useLocation } from "@/lib/state/location";
 import animatedRouteA from "../../data/animated_route.json";
 import animatedRouteB from "../../data/animated_route_alt.json";
 import landmarkChange from "../../data/landmark_change.json";
@@ -21,6 +22,7 @@ export default function DebugMenu() {
   const [open, setOpen] = useState(false);
   const { setStatus, setRoute } = useDebug();
   const { addLandmark } = useLandmarks();
+  const { setLastKnownLocation } = useLocation();
 
   const toggle = useCallback(() => setOpen((o) => !o), []);
 
@@ -40,7 +42,11 @@ export default function DebugMenu() {
       {
         key: "8",
         label: "Start Route",
-        handler: () => setRoute(animatedRouteA as LineString),
+        handler: () => {
+          setRoute(animatedRouteA as LineString);
+          const [lng, lat] = animatedRouteA.coordinates[0];
+          setLastKnownLocation({ lat, lng });
+        },
         metaRequired: true,
       },
       {
@@ -63,7 +69,7 @@ export default function DebugMenu() {
         })
       ),
     ],
-    [addLandmark, setRoute, setStatus]
+    [addLandmark, setRoute, setStatus, setLastKnownLocation]
   );
 
   const handleKey = useCallback(

--- a/src/lib/state/debug.tsx
+++ b/src/lib/state/debug.tsx
@@ -8,7 +8,6 @@ import {
 
 import type { SystemStatus } from "@/types/status";
 import type { LineString } from "geojson";
-import animatedRouteA from "../../../data/animated_route.json";
 
 interface DebugContextType {
   status: SystemStatus;
@@ -21,7 +20,7 @@ const DebugContext = createContext<DebugContextType | undefined>(undefined);
 
 export function DebugProvider({ children }: { children: ReactNode }) {
   const [status, setStatus] = useState<SystemStatus>("Online");
-  const [route, setRoute] = useState<LineString | null>(animatedRouteA as LineString);
+  const [route, setRoute] = useState<LineString | null>(null);
 
 
   return (

--- a/src/lib/state/location.tsx
+++ b/src/lib/state/location.tsx
@@ -2,7 +2,7 @@
 import { createContext, useContext, useState, ReactNode } from "react";
 import type { Location } from "@/lib/types";
 
-const defaultLocation: Location = { lat: 35.688, lng: 51.334 };
+const defaultLocation: Location = { lat: 35.751, lng: 51.438 };
 
 interface LocationContextType {
     lastKnownLocation: Location;


### PR DESCRIPTION
## Summary
- start with no debug route visible
- move user location to the first point when starting a route
- use the first route coordinate as the default location

## Testing
- `npm run lint` *(fails: LandmarkCategory unused, Unexpected any in googlePlaces)*

------
https://chatgpt.com/codex/tasks/task_e_6857d512430c832f925dbb7a65878094